### PR TITLE
Adds server hooks for pre-cmd and pre-start and a no-op implementation

### DIFF
--- a/internal/server/server_hooks.go
+++ b/internal/server/server_hooks.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"errors"
+	"github.com/tidwall/tile38/internal/log"
+)
+
+var errCannotExecuteServerHook = errors.New("cannot execute server hook")
+
+type SHooks interface {
+	PreStartHook() error
+	PreCmdHook(cmd Message) error
+}
+
+type NoOpHook struct {
+}
+
+func NewNoOpHook(server Server) SHooks {
+	return NoOpHook{}
+}
+
+func (n NoOpHook) PreStartHook() error {
+	log.Debug("Executing pre-start hook")
+	return nil
+}
+
+func (n NoOpHook) PreCmdHook(cmd Message) error {
+	log.Debugf("Executing pre-cmd hook for cmd %s", cmd._command)
+	return nil
+}
+

--- a/internal/server/server_hooks_test.go
+++ b/internal/server/server_hooks_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewNoOpHook(t *testing.T) {
+	type args struct {
+		server Server
+	}
+	tests := []struct {
+		name string
+		args args
+		want SHooks
+	}{
+		{"ShouldGetNoOpHook", args{Server{}}, NoOpHook{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewNoOpHook(tt.args.server); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewNoOpHook() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNoOpHook_PreCmdHook(t *testing.T) {
+	type args struct {
+		cmd Message
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"NoErrOnAnything", args{Message{}}, false},
+		{"NoErrOnUnknownCmd", args{Message{_command:"XYZ"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NoOpHook{}
+			if err := n.PreCmdHook(tt.args.cmd); (err != nil) != tt.wantErr {
+				t.Errorf("PreCmdHook() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNoOpHook_PreStartHook(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"NoErrOnAnything", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NoOpHook{}
+			if err := n.PreStartHook(); (err != nil) != tt.wantErr {
+				t.Errorf("PreStartHook() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/server/server_hooks_wire.go
+++ b/internal/server/server_hooks_wire.go
@@ -1,0 +1,6 @@
+package server
+
+func NewServerHooks(server Server) (SHooks, error) {
+	// Wire the hook that you want, NoOp is wired by default
+	return NewNoOpHook(server), nil
+}


### PR DESCRIPTION
This is a proof-of-concept implementation for server hooks proposed in : https://github.com/tidwall/tile38/issues/520